### PR TITLE
TEST: add operator e2e test for dashboards

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,1 +1,6 @@
 golang-version=1.26
+kind-version=v0.32.0
+kind-node-image=kindest/node:v1.36.1
+helm-version=v3.21.4
+perses-operator-version=0.5.0
+perses-version=0.54.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,6 +27,7 @@ jobs:
           version: ${{ env.kind-version }}
           node_image: ${{ env.kind-node-image }}
           config: test/e2e/kind/config.yml
+          cluster_name: community-mixins-e2e
           wait: 300s
 
       - uses: azure/setup-helm@v5
@@ -38,8 +39,6 @@ jobs:
 
       - name: Run operator e2e tests
         run: make test-e2e-operator
-        env:
-          KUBECONFIG: ${{ env.KUBECONFIG }}
 
       - name: Debug cluster state on failure
         if: failure()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,50 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  operator-e2e:
+    runs-on: ubuntu-latest
+    name: Operator dashboard reconciliation
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "${{ env.golang-version }}"
+          check-latest: false
+          cache: true
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: ${{ env.kind-version }}
+          node_image: ${{ env.kind-node-image }}
+          config: test/e2e/kind/config.yml
+          wait: 300s
+
+      - uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.helm-version }}
+
+      - name: Install e2e stack
+        run: make e2e-install
+
+      - name: Run operator e2e tests
+        run: make test-e2e-operator
+        env:
+          KUBECONFIG: ${{ env.KUBECONFIG }}
+
+      - name: Debug cluster state on failure
+        if: failure()
+        run: |
+          kubectl get perses,persesdashboards -A
+          kubectl get pods,svc,endpoints -n perses-dev
+          kubectl describe pods -n perses-dev
+          kubectl get events -n perses-dev --sort-by=.lastTimestamp | tail -n 50

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ vet:
 .PHONY: unit-test
 unit-test:
 	@echo ">> running unit tests"
-	$(GOCMD) test -v ./...
+	$(GOCMD) test -v $(shell $(GOCMD) list ./... | grep -v '/test/e2e$$')
 
 .PHONY: test-e2e-operator
 test-e2e-operator:
@@ -96,7 +96,7 @@ E2E_KIND_CLUSTER ?= community-mixins-e2e
 
 .PHONY: e2e e2e-up e2e-install e2e-down
 e2e: e2e-up
-	@KUBECONFIG="$$(kind get kubeconfig --name $(E2E_KIND_CLUSTER))" $(MAKE) test-e2e-operator
+	@$(MAKE) test-e2e-operator
 
 e2e-up:
 	@bash test/e2e/setup.sh up

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,26 @@ unit-test:
 	@echo ">> running unit tests"
 	$(GOCMD) test -v ./...
 
+.PHONY: test-e2e-operator
+test-e2e-operator:
+	@echo ">> running operator dashboard e2e tests"
+	OPERATOR_E2E=true $(GOCMD) test -v -count=1 ./test/e2e/... -timeout 20m
+
+E2E_KIND_CLUSTER ?= community-mixins-e2e
+
+.PHONY: e2e e2e-up e2e-install e2e-down
+e2e: e2e-up
+	@KUBECONFIG="$$(kind get kubeconfig --name $(E2E_KIND_CLUSTER))" $(MAKE) test-e2e-operator
+
+e2e-up:
+	@bash test/e2e/setup.sh up
+
+e2e-install:
+	@bash test/e2e/setup.sh install
+
+e2e-down:
+	@bash test/e2e/setup.sh down
+
 .PHONY: check-golang
 check-golang: $(GOLANGCILINTER_BINARY)
 	$(GOLANGCILINTER_BINARY) run

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,7 +28,8 @@ Version pins (operator, Perses, kind node image, etc.) live in [`.github/env`](.
 If the cluster is already up from a previous `make e2e`:
 
 ```sh
-make test-e2e-operator KUBECONFIG="$(kind get kubeconfig --name community-mixins-e2e)"
+make test-e2e-operator
 ```
 
 Tests require `OPERATOR_E2E=true` (set automatically by `make test-e2e-operator`).
+They use the same default kubeconfig as `kubectl` after `make e2e` / kind cluster creation.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,34 @@
+# Testing
+
+## Unit tests
+
+```sh
+make unit-test
+```
+
+## Operator E2E tests
+
+Validates that mixin-built `PersesDashboard` CRs reconcile through
+[perses-operator](https://github.com/perses/perses-operator) on a local kind cluster.
+CI runs via `.github/workflows/e2e.yaml`.
+
+**Prerequisites:** Docker, [kind](https://kind.sigs.k8s.io/), Helm 3, kubectl, Go.
+
+### Local run
+
+```sh
+make e2e        # create cluster, install stack, run tests
+make e2e-down   # delete the kind cluster
+```
+
+Version pins (operator, Perses, kind node image, etc.) live in [`.github/env`](.github/env).
+
+### Re-run tests only
+
+If the cluster is already up from a previous `make e2e`:
+
+```sh
+make test-e2e-operator KUBECONFIG="$(kind get kubeconfig --name community-mixins-e2e)"
+```
+
+Tests require `OPERATOR_E2E=true` (set automatically by `make test-e2e-operator`).

--- a/go.mod
+++ b/go.mod
@@ -20,12 +20,29 @@ require (
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.3
+	k8s.io/client-go v0.36.3
 	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/go-openapi/jsonpointer v0.23.2 // indirect
+	github.com/go-openapi/jsonreference v0.21.6 // indirect
+	github.com/go-openapi/swag v0.26.1 // indirect
+	github.com/go-openapi/swag/cmdutils v0.26.1 // indirect
+	github.com/go-openapi/swag/conv v0.26.1 // indirect
+	github.com/go-openapi/swag/fileutils v0.26.1 // indirect
+	github.com/go-openapi/swag/jsonname v0.26.1 // indirect
+	github.com/go-openapi/swag/jsonutils v0.26.1 // indirect
+	github.com/go-openapi/swag/loading v0.26.1 // indirect
+	github.com/go-openapi/swag/mangling v0.26.1 // indirect
+	github.com/go-openapi/swag/netutils v0.26.1 // indirect
+	github.com/go-openapi/swag/stringutils v0.26.1 // indirect
+	github.com/go-openapi/swag/typeutils v0.26.1 // indirect
+	github.com/go-openapi/swag/yamlutils v0.26.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/perses/spec v0.2.0 // indirect
@@ -34,7 +51,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	k8s.io/client-go v0.36.3 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
@@ -89,7 +106,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720155508-bb71a54f79dc // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.36.3 // indirect
+	k8s.io/api v0.36.3
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/go-openapi/swag/jsonname v0.26.1 h1:VReupaV6WxlAsCn0e4DUfgV6bPmINnPpy
 github.com/go-openapi/swag/jsonname v0.26.1/go.mod h1:OvdW6BoWoj33pTfi7x9vFrgmT+fk7aw0BRwvCE0YOuc=
 github.com/go-openapi/swag/jsonutils v0.26.1 h1:2hdBfFkHg+7Wrz2VsCbeyR6hzkRDs7AztnMR2u84yOY=
 github.com/go-openapi/swag/jsonutils v0.26.1/go.mod h1:U+RMJH3wa+6BRiphuRtIyI8fW9HPFqFQ4sHk2oRx0UQ=
+github.com/go-openapi/swag/jsonutils/fixtures_test v0.26.1 h1:1CD7NiLLb/TXl3tOnFYU4b+mNfb5rtgHkaA+q7RMYYQ=
+github.com/go-openapi/swag/jsonutils/fixtures_test v0.26.1/go.mod h1:ZWafc8nMdYzTE3uYY6W86f0n46+IF0g4uUyRhJw/kXc=
 github.com/go-openapi/swag/loading v0.26.1 h1:E9K4wqXeROlhjFQ13K9zMz6ojFGXIggGe+ad1odrK9w=
 github.com/go-openapi/swag/loading v0.26.1/go.mod h1:3qvRIlWzWdq1HvmldwmuJ2ohpcAryN6xVt2OTKd0/7E=
 github.com/go-openapi/swag/mangling v0.26.1 h1:gpYI4WuPKFJJVjV5cDLGlDVJhFIxYjQc7yN5eEb4CqM=
@@ -111,6 +113,10 @@ github.com/go-openapi/swag/typeutils v0.26.1 h1:yg42FgMzRR6PVQ3M3qHz1s+Y6/P4HoJ3
 github.com/go-openapi/swag/typeutils v0.26.1/go.mod h1:VfnV+oUtSP2vCSCn2aJgnr8OevUYemyIzzS1VOzS10o=
 github.com/go-openapi/swag/yamlutils v0.26.1 h1:0TSLK+lXs9vfIhAWzBeI/lOzEnIoot6WTCO1aAeWFTk=
 github.com/go-openapi/swag/yamlutils v0.26.1/go.mod h1:7W5b7PRX9MxwL7TjeG7H8HkyBGRsIDRObhyMWFgBI2M=
+github.com/go-openapi/testify/enable/yaml/v2 v2.5.1 h1:q9NtHwK4qHF7yZziBPvZyv7zWAIk8ok88Gh2mR6Jpc8=
+github.com/go-openapi/testify/enable/yaml/v2 v2.5.1/go.mod h1:JW0MXIotCYps/XsgJnG3a8Q7rE5xAiBwoOD5OfaIQBk=
+github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
+github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -31,13 +31,14 @@ import (
 )
 
 const (
-	testNamespace              = "perses-dev"
-	persesInstanceName         = "perses"
-	operatorDeploymentName     = "perses-operator-controller-manager"
-	operatorPodLabelSelector   = "control-plane=controller-manager"
-	operatorManagerContainer   = "manager"
-	persesAvailableCondition   = "Available"
-	persesDegradedCondition    = "Degraded"
+	testNamespace            = "perses-dev"
+	persesInstanceName       = "perses"
+	operatorDeploymentName   = "perses-operator-controller-manager"
+	operatorPodLabelSelector = "control-plane=controller-manager"
+	operatorManagerContainer = "manager"
+	persesAvailableCondition = "Available"
+	persesDegradedCondition  = "Degraded"
+	persesContainerPort      = "8080"
 )
 
 var kubeClient kubernetes.Interface
@@ -114,19 +115,25 @@ func persesInstanceReady(kClient kubernetes.Interface) error {
 	return nil
 }
 
-func persesServiceEndpointsReady(kClient kubernetes.Interface) error {
-	endpoints, err := kClient.CoreV1().Endpoints(testNamespace).Get(context.Background(), persesInstanceName, metav1.GetOptions{})
-	if err != nil {
-		return err
+func persesPodProxyName(kClient kubernetes.Interface) (string, error) {
+	if _, err := kClient.AppsV1().StatefulSets(testNamespace).Get(context.Background(), persesInstanceName, metav1.GetOptions{}); err == nil {
+		return fmt.Sprintf("%s-0:%s", persesInstanceName, persesContainerPort), nil
 	}
 
-	for _, subset := range endpoints.Subsets {
-		if len(subset.Addresses) > 0 {
-			return nil
+	pods, err := kClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/instance=perses,app.kubernetes.io/managed-by=perses-operator",
+	})
+	if err != nil {
+		return "", err
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			return fmt.Sprintf("%s:%s", pod.Name, persesContainerPort), nil
 		}
 	}
 
-	return fmt.Errorf("perses service has no ready endpoints")
+	return "", fmt.Errorf("no running perses pod found")
 }
 
 type persesDashboardItem struct {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1,0 +1,258 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	testNamespace              = "perses-dev"
+	persesInstanceName         = "perses"
+	operatorDeploymentName     = "perses-operator-controller-manager"
+	operatorPodLabelSelector   = "control-plane=controller-manager"
+	operatorManagerContainer   = "manager"
+	persesAvailableCondition   = "Available"
+	persesDegradedCondition    = "Degraded"
+)
+
+var kubeClient kubernetes.Interface
+
+func builtOperatorDashboardDir() string {
+	return filepath.Join("..", "..", "built", "dashboards", "operator")
+}
+
+func countBuiltOperatorDashboards() (int, error) {
+	dir := builtOperatorDashboardDir()
+	var count int
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml") {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("walk %s: %w", dir, err)
+	}
+	if count == 0 {
+		return 0, fmt.Errorf("no operator dashboard YAML found under %s", dir)
+	}
+	return count, nil
+}
+
+func pollCondition(timeout time.Duration, conditionFunc func() error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var conditionErr error
+	if err := wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(context.Context) (bool, error) {
+		conditionErr = conditionFunc()
+		return conditionErr == nil, nil
+	}); err != nil {
+		return fmt.Errorf("%w: %w", err, conditionErr)
+	}
+
+	return nil
+}
+
+func requireOperatorE2E(t *testing.T) {
+	t.Helper()
+	if os.Getenv("OPERATOR_E2E") != "true" {
+		t.Skip("OPERATOR_E2E != true, skipping operator e2e tests")
+	}
+	if kubeClient == nil {
+		t.Fatal("kubeClient is not initialized; set KUBECONFIG when OPERATOR_E2E=true")
+	}
+}
+
+func persesInstanceReady(kClient kubernetes.Interface) error {
+	statefulSet, err := kClient.AppsV1().StatefulSets(testNamespace).Get(context.Background(), persesInstanceName, metav1.GetOptions{})
+	if err == nil {
+		if statefulSet.Status.ReadyReplicas < 1 {
+			return fmt.Errorf("expecting at least 1 ready perses replica, got %d", statefulSet.Status.ReadyReplicas)
+		}
+		return nil
+	}
+
+	deploy, err := kClient.AppsV1().Deployments(testNamespace).Get(context.Background(), persesInstanceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("perses workload not found: %w", err)
+	}
+	if deploy.Status.ReadyReplicas != *deploy.Spec.Replicas {
+		return fmt.Errorf("expecting %d ready perses replicas, got %d", *deploy.Spec.Replicas, deploy.Status.ReadyReplicas)
+	}
+	return nil
+}
+
+func persesServiceEndpointsReady(kClient kubernetes.Interface) error {
+	endpoints, err := kClient.CoreV1().Endpoints(testNamespace).Get(context.Background(), persesInstanceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, subset := range endpoints.Subsets {
+		if len(subset.Addresses) > 0 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("perses service has no ready endpoints")
+}
+
+type persesDashboardItem struct {
+	Name       string
+	Conditions []metav1.Condition
+}
+
+func listPersesDashboardsWithStatus(kClient kubernetes.Interface) ([]persesDashboardItem, error) {
+	raw, err := kClient.CoreV1().RESTClient().Get().
+		AbsPath("/apis/perses.dev/v1alpha2/namespaces", testNamespace, "persesdashboards").
+		DoRaw(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Status struct {
+				Conditions []metav1.Condition `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, err
+	}
+
+	dashboards := make([]persesDashboardItem, 0, len(list.Items))
+	for _, item := range list.Items {
+		dashboards = append(dashboards, persesDashboardItem{
+			Name:       item.Metadata.Name,
+			Conditions: item.Status.Conditions,
+		})
+	}
+
+	return dashboards, nil
+}
+
+func getPersesCRConditions(kClient kubernetes.Interface) ([]metav1.Condition, error) {
+	raw, err := kClient.CoreV1().RESTClient().Get().
+		AbsPath("/apis/perses.dev/v1alpha2/namespaces", testNamespace, "perses", persesInstanceName).
+		DoRaw(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	var perses struct {
+		Status struct {
+			Conditions []metav1.Condition `json:"conditions"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &perses); err != nil {
+		return nil, err
+	}
+
+	return perses.Status.Conditions, nil
+}
+
+func getCondition(conditions []metav1.Condition, conditionType string) (metav1.Condition, bool) {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition, true
+		}
+	}
+	return metav1.Condition{}, false
+}
+
+func assertReconciledConditions(conditions []metav1.Condition, resourceName string) error {
+	available, ok := getCondition(conditions, persesAvailableCondition)
+	if !ok || available.Status != metav1.ConditionTrue {
+		detail := "condition not set"
+		if ok {
+			detail = fmt.Sprintf("reason=%s message=%s", available.Reason, available.Message)
+		}
+		return fmt.Errorf("%s: Available!=True (%s)", resourceName, detail)
+	}
+
+	degraded, ok := getCondition(conditions, persesDegradedCondition)
+	if !ok {
+		return fmt.Errorf("%s: Degraded condition not set", resourceName)
+	}
+	if degraded.Status == metav1.ConditionTrue {
+		return fmt.Errorf("%s: Degraded=True reason=%s message=%s", resourceName, degraded.Reason, degraded.Message)
+	}
+	if degraded.Status != metav1.ConditionFalse {
+		return fmt.Errorf("%s: Degraded=%s reason=%s message=%s", resourceName, degraded.Status, degraded.Reason, degraded.Message)
+	}
+
+	return nil
+}
+
+func getOperatorManagerLogs(kClient kubernetes.Interface, tailLines int64) (string, error) {
+	pods, err := kClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: operatorPodLabelSelector,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("perses-operator pod not found")
+	}
+
+	tail := tailLines
+	req := kClient.CoreV1().Pods(testNamespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{
+		Container: operatorManagerContainer,
+		TailLines: &tail,
+	})
+	logBytes, err := req.DoRaw(context.Background())
+	if err != nil {
+		return "", err
+	}
+
+	return string(logBytes), nil
+}
+
+func formatOperatorDebug(err error) error {
+	if kubeClient == nil {
+		return err
+	}
+
+	logs, logErr := getOperatorManagerLogs(kubeClient, 200)
+	if logErr != nil {
+		return fmt.Errorf("%w\n\nfailed to fetch perses-operator logs: %v", err, logErr)
+	}
+
+	return fmt.Errorf("%w\n\nrecent perses-operator manager logs:\n%s", err, logs)
+}

--- a/test/e2e/kind/config.yml
+++ b/test/e2e/kind/config.yml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: "10.10.0.0/16"
+  serviceSubnet: "10.11.0.0/16"
+nodes:
+  - role: control-plane

--- a/test/e2e/lib/env.sh
+++ b/test/e2e/lib/env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+get_env() {
+  local key="$1"
+  local default="$2"
+  if [[ -f "${ENV_FILE}" ]]; then
+    local value
+    value="$(grep -E "^${key}=" "${ENV_FILE}" | tail -1 | cut -d= -f2-)"
+    if [[ -n "${value}" ]]; then
+      printf '%s' "${value}"
+      return
+    fi
+  fi
+  printf '%s' "${default}"
+}
+
+require_env() {
+  local key="$1"
+  local value
+  value="$(get_env "${key}" "")"
+  if [[ -z "${value}" ]]; then
+    echo "missing ${key} in ${ENV_FILE}" >&2
+    exit 1
+  fi
+  printf '%s' "${value}"
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,52 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
+	if os.Getenv("OPERATOR_E2E") != "true" {
+		return m.Run()
+	}
+
+	kubeConfigPath, ok := os.LookupEnv("KUBECONFIG")
+	if !ok {
+		log.Fatal("failed to retrieve KUBECONFIG env var")
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatal(fmt.Errorf("creating kubeClient failed: %w", err))
+	}
+	kubeClient = client
+
+	return m.Run()
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -32,12 +33,7 @@ func testMain(m *testing.M) int {
 		return m.Run()
 	}
 
-	kubeConfigPath, ok := os.LookupEnv("KUBECONFIG")
-	if !ok {
-		log.Fatal("failed to retrieve KUBECONFIG env var")
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	config, err := loadKubeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,4 +45,13 @@ func testMain(m *testing.M) int {
 	kubeClient = client
 
 	return m.Run()
+}
+
+func loadKubeConfig() (*rest.Config, error) {
+	if kubeConfigPath := os.Getenv("KUBECONFIG"); kubeConfigPath != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 }

--- a/test/e2e/manifests/README.md
+++ b/test/e2e/manifests/README.md
@@ -1,0 +1,9 @@
+# E2E manifests
+
+| Path | Purpose |
+| ---- | ------- |
+| `perses/` | `Perses` CR and stub `PersesGlobalDatasource` |
+
+The operator is installed via Helm; Perses fixtures and dashboards are applied by
+`test/e2e/setup.sh` (`make e2e-up` / `make e2e-install`). Version pins are in
+[`.github/env`](../../.github/env).

--- a/test/e2e/manifests/perses/perses.yaml
+++ b/test/e2e/manifests/perses/perses.yaml
@@ -1,0 +1,24 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses
+  namespace: perses-dev
+  labels:
+    app.kubernetes.io/name: perses
+    app.kubernetes.io/instance: perses
+    app.kubernetes.io/part-of: perses-operator
+    app.kubernetes.io/created-by: controller-manager
+    app.kubernetes.io/managed-by: perses-operator
+spec:
+  containerPort: 8080
+  image: persesdev/perses:v0.54.0
+  config:
+    security:
+      readonly: false
+      enable_auth: false
+      cookie:
+        secure: false
+    database:
+      file:
+        folder: /perses/data
+        extension: json

--- a/test/e2e/manifests/perses/prometheus-global-datasource.yaml
+++ b/test/e2e/manifests/perses/prometheus-global-datasource.yaml
@@ -1,0 +1,23 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesGlobalDatasource
+metadata:
+  name: prometheus-datasource
+  labels:
+    app.kubernetes.io/name: perses
+    app.kubernetes.io/instance: perses
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/name: perses
+      app.kubernetes.io/instance: perses
+  config:
+    display:
+      name: Prometheus
+    default: true
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: http://prometheus.example:9090

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,0 +1,120 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOperatorDashboardReconciliation(t *testing.T) {
+	requireOperatorE2E(t)
+
+	t.Run("operator deployment is ready", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			deploy, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.Background(), operatorDeploymentName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if deploy.Status.ReadyReplicas != *deploy.Spec.Replicas {
+				return fmt.Errorf("expecting %d ready replicas, got %d", *deploy.Spec.Replicas, deploy.Status.ReadyReplicas)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(formatOperatorDebug(err))
+		}
+	})
+
+	t.Run("perses instance is ready", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			return persesInstanceReady(kubeClient)
+		})
+		if err != nil {
+			t.Fatal(formatOperatorDebug(err))
+		}
+	})
+
+	t.Run("perses CR status is available and not degraded", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			conditions, err := getPersesCRConditions(kubeClient)
+			if err != nil {
+				return err
+			}
+			return assertReconciledConditions(conditions, "Perses/"+persesInstanceName)
+		})
+		if err != nil {
+			t.Fatal(formatOperatorDebug(err))
+		}
+	})
+
+	t.Run("perses service responds", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			if err := persesServiceEndpointsReady(kubeClient); err != nil {
+				return err
+			}
+
+			_, err := kubeClient.CoreV1().RESTClient().Get().
+				Namespace(testNamespace).
+				Resource("services").
+				Name("perses:http").
+				SubResource("proxy").
+				Suffix("/api/v1/health").
+				DoRaw(context.Background())
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("dashboards reconcile", func(t *testing.T) {
+		expected, err := countBuiltOperatorDashboards()
+		if err != nil {
+			t.Fatalf("count built operator dashboards: %v", err)
+		}
+
+		err = pollCondition(5*time.Minute, func() error {
+			dashboards, err := listPersesDashboardsWithStatus(kubeClient)
+			if err != nil {
+				return err
+			}
+			if len(dashboards) != expected {
+				return fmt.Errorf("expected %d PersesDashboard objects, got %d", expected, len(dashboards))
+			}
+
+			for _, dashboard := range dashboards {
+				if err := assertReconciledConditions(dashboard.Conditions, "PersesDashboard/"+dashboard.Name); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(formatOperatorDebug(err))
+		}
+	})
+}
+
+func TestOperatorE2ESkipsWithoutEnv(t *testing.T) {
+	if os.Getenv("OPERATOR_E2E") == "true" {
+		t.Skip("OPERATOR_E2E=true, covered by reconciliation tests")
+	}
+	requireOperatorE2E(t)
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -66,14 +66,15 @@ func TestOperatorDashboardReconciliation(t *testing.T) {
 
 	t.Run("perses service responds", func(t *testing.T) {
 		err := pollCondition(5*time.Minute, func() error {
-			if err := persesServiceEndpointsReady(kubeClient); err != nil {
+			proxyName, err := persesPodProxyName(kubeClient)
+			if err != nil {
 				return err
 			}
 
-			_, err := kubeClient.CoreV1().RESTClient().Get().
+			_, err = kubeClient.CoreV1().RESTClient().Get().
 				Namespace(testNamespace).
-				Resource("services").
-				Name("perses:http").
+				Resource("pods").
+				Name(proxyName).
 				SubResource("proxy").
 				Suffix("/api/v1/health").
 				DoRaw(context.Background())

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.github/env"
+# shellcheck source=test/e2e/lib/env.sh
+source "${ROOT_DIR}/test/e2e/lib/env.sh"
+
+E2E_KIND_CLUSTER="${E2E_KIND_CLUSTER:-community-mixins-e2e}"
+E2E_NAMESPACE="perses-dev"
+HELM_REPO="https://perses.github.io/helm-charts"
+HELM_RELEASE="perses-operator"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <up|install|down>
+
+  up       Create the kind cluster (if needed) and install the e2e stack
+  install  Install operator, Perses, built dashboards (cluster must exist)
+  down     Delete the kind cluster
+EOF
+}
+
+install_operator() {
+  local operator_chart_version operator_image_tag
+  operator_chart_version="$(require_env perses-operator-version)"
+  operator_image_tag="v${operator_chart_version#v}"
+
+  helm repo add perses "${HELM_REPO}" 2>/dev/null || true
+
+  helm upgrade --install "${HELM_RELEASE}" perses/perses-operator \
+    --version "${operator_chart_version}" \
+    --namespace "${E2E_NAMESPACE}" \
+    --create-namespace \
+    --set certManager.enable=false \
+    --set testFramework.enabled=false \
+    --set "manager.image.tag=${operator_image_tag}" \
+    --wait \
+    --timeout 5m
+}
+
+apply_perses_fixtures() {
+  local perses_version perses_image
+  perses_version="$(require_env perses-version)"
+  perses_version="${perses_version#v}"
+  perses_image="persesdev/perses:v${perses_version}"
+
+  sed "s|image: persesdev/perses:v[^[:space:]]*|image: ${perses_image}|" \
+    "${ROOT_DIR}/test/e2e/manifests/perses/perses.yaml" | kubectl apply -f -
+
+  kubectl apply -f "${ROOT_DIR}/test/e2e/manifests/perses/prometheus-global-datasource.yaml"
+}
+
+wait_for_stack() {
+  kubectl wait --for=condition=Ready pods -l control-plane=controller-manager \
+    -n "${E2E_NAMESPACE}" --timeout=300s
+  kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 statefulset/perses \
+    -n "${E2E_NAMESPACE}" --timeout=600s
+}
+
+apply_dashboards() {
+  "${MAKE:-make}" -C "${ROOT_DIR}" build-dashboards-local \
+    PROJECT=perses-dev DATASOURCE=prometheus-datasource
+  kubectl apply -R -f "${ROOT_DIR}/built/dashboards/operator/"
+}
+
+install_stack() {
+  install_operator
+  apply_perses_fixtures
+  wait_for_stack
+  apply_dashboards
+}
+
+kind_up() {
+  local kind_node_image
+  kind_node_image="$(require_env kind-node-image)"
+
+  if ! kind get clusters 2>/dev/null | grep -Fxq "${E2E_KIND_CLUSTER}"; then
+    kind create cluster --name "${E2E_KIND_CLUSTER}" \
+      --config "${ROOT_DIR}/test/e2e/kind/config.yml" \
+      --image "${kind_node_image}"
+  fi
+
+  export KUBECONFIG="$(kind get kubeconfig --name "${E2E_KIND_CLUSTER}")"
+  install_stack
+}
+
+kind_down() {
+  kind delete cluster --name "${E2E_KIND_CLUSTER}"
+}
+
+case "${1:-}" in
+  up)
+    kind_up
+    ;;
+  install)
+    install_stack
+    ;;
+  down)
+    kind_down
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -81,7 +81,6 @@ kind_up() {
       --image "${kind_node_image}"
   fi
 
-  export KUBECONFIG="$(kind get kubeconfig --name "${E2E_KIND_CLUSTER}")"
   install_stack
 }
 


### PR DESCRIPTION
# What this PR does

<!-- A brief description of the change. -->

Add perses-operator e2e test for dashboards

## Why

<!-- Why is this change needed? Link any related issues. -->

To catch issues with dashboards with operator reconcilation early when a new update or new dashboards are added

Fixes #280 

## Type of change

- [ ] Bug fix
- [ ] New feature (dashboard, panel, rule, etc.)
- [ ] Enhancement to existing mixin
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [x] CI / Build / Tooling

## Checklist

- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
- [ ] I have run `make build-dashboards` and verified the generated output
- [ ] I have run `make lint` with no new warnings
- [x] I have tested my changes locally
- [x] I have updated documentation if needed

## Additional notes

<!-- Any additional context, screenshots, or information for reviewers. -->
